### PR TITLE
Fix formatting to allow for new format alongside old one

### DIFF
--- a/prettify.pl
+++ b/prettify.pl
@@ -257,7 +257,7 @@ while ($_ = <$ifd>) {
     }  
 
     # Get Location
-    if (/Location\s([\d]+)/) {
+    if (/[Ll]ocation\s([\d]+)/) {
       $loc = $1; # print "location: $loc\n";
     } elsif (/[Pp]age\s([\d]+)/) {
       $loc = $1; # print "page: $loc\n";


### PR DESCRIPTION
My kindle is using this format. Making a change in the parsing logic for `location` so that this works.

The new format:
```
The Phoenix Project (Kim, Gene)
- Your Highlight at location 2621-2621 | Added on Thursday, 23 January 2020 03:04:02

always do whatever it takes to eradicate it. Murphy
==========
My Life: An Illustrated Biography (Kalam, A.P.J. Abdul)
- Your Highlight on page 21 | location 195-196 | Added on Monday, 4 May 2020 23:37:18

‘Let not thy winged days be spent in vain. When once gone, no gold can buy them back.’
==========
```